### PR TITLE
Add ability for exceptions such as libmryipc

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -1,11 +1,25 @@
 #import <os/log.h>
 
+static const char *exceptions[] = {
+	"/Library/MobileSubstrate/DynamicLibraries/mrybootstrap.dylib",
+	"/usr/lib/TweakInject/mrybootstrap.dylib",
+	NULL
+};
+
+static BOOL isAllowed(const char *path) {
+	for (const char **exception = exceptions; *exception; exception++) {
+		if (strcmp(*exception, path) == 0)
+			return YES;
+	}
+	return NO;
+}
+
 static BOOL hasPrefix(const char *string, const char *prefix) {
 	return strncmp(prefix, string, strlen(prefix)) == 0;
 }
 
 %hookf(void *, dlopen, const char *path, int mode) {
-	if (hasPrefix(path, "/Library/MobileSubstrate/DynamicLibraries") || hasPrefix(path, "/usr/lib/TweakInject")) {
+	if ((hasPrefix(path, "/Library/MobileSubstrate/DynamicLibraries/") || hasPrefix(path, "/usr/lib/TweakInject/")) && !isAllowed(path)) {
 		os_log(OS_LOG_DEFAULT, "stopcrashingpls: Loading of %{public}s was blocked.", path);
 		return NULL;
 	}


### PR DESCRIPTION
This PR adds an `exceptions` array to allow implementing a whitelist for the few tweaks that you do want to allow to be injected.